### PR TITLE
v1.0.2 Fix: Remove babel 6 dep

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.2
+- manifest: rm babel 6 dep
+
 # 1.0.1
 - manifest: bump deps
 - meta: add github issue/pr templates

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "lodash": "^4.17.10"
   },
   "devDependencies": {
-    "babel": "^6.23.0",
     "babel-eslint": "^7.2.2",
     "babel-loader": "^6.4.1",
     "babel-plugin-import-directory": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-strategy",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "HF strategy module",
   "main": "./index.js",
   "directories": {


### PR DESCRIPTION
### Description:
Removes `babel` dep from `devDependencies` causing `npm i` failure (specifically when running the `bfx-hf-indicators` postinstall build step.

### Fixes:
- [x] `npm i`

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
