### PR TITLE
dazaar: add support for live streams

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# 1.1.0
+
+ - stream support for Dazaar/hypercore/Bitfinex Terminal
+
 # 1.0.5
 - remove babel compiling
 - add missing dependencies

--- a/lib/orders/submit_trade.js
+++ b/lib/orders/submit_trade.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const submitOrder = require('./submit_order')
+const _submitOrder = require('./submit_order')
 const simulateOrderFill = require('./simulate_order_fill')
 const tradeForOrder = require('./trade_for_order')
 
@@ -12,12 +12,25 @@ const tradeForOrder = require('./trade_for_order')
  * @return {Object} res - map of order and trade objects
  */
 module.exports = async (state = {}, orderParams = {}) => {
-  const { ws } = state
-  const backtesting = !ws
+  let {
+    ws,
+    backtesting,
+    submitOrder = _submitOrder,
+    simulateFill
+  } = state
 
-  const o = !backtesting
-    ? await submitOrder(state, orderParams)
-    : simulateOrderFill(state, orderParams)
+  // backwards compat
+  if (backtesting !== true && backtesting !== false) {
+    backtesting = !ws
+  }
+
+  let o
+
+  if (simulateFill || backtesting) {
+    o = simulateOrderFill(state, orderParams)
+  } else {
+    o = await submitOrder(state, orderParams)
+  }
 
   const trade = tradeForOrder(state, o, orderParams.label, orderParams.tag)
   const tradeData = { o, trade }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-strategy",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "HF strategy module",
   "main": "./index.js",
   "directories": {


### PR DESCRIPTION
### Description:

dazaar: add support for live streams

### Breaking changes:
We **could** make the new `backtesting` flag mandatory, right now we use a fallback for it. Probably good to remove at a later point.

So right now no breaking changes.

### New features:
- [x] possibility to add a custom submit order function which is not tied to a websocket
- [x] adds an explicit `backtesting` flag to remove ambiguity

### Fixes:
- [ ]

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
