### PR TITLE
fix report trade amounts

### DIFF
--- a/lib/util/generate_strategy_results.js
+++ b/lib/util/generate_strategy_results.js
@@ -11,7 +11,8 @@ const _isPlainObject = require('lodash/isPlainObject')
 
 const TRADE_FIELDS = [
   'order_id', 'amount', 'order_js.type', 'order_js.mtsCreate',
-  'order_js.mtsUpdate', 'order_js.price', 'order_js.priceAvg'
+  'order_js.mtsUpdate', 'order_js.price', 'order_js.priceAvg',
+  'order_js.amount', 'order_js.amountOrig'
 ]
 
 const formatPositions = (positions = []) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-strategy",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "HF strategy module",
   "main": "./index.js",
   "directories": {


### PR DESCRIPTION
Amount fields are used by the UI [here](https://github.com/bitfinexcom/bfx-hf-ui-core/blob/main/src/components/StrategyTradesTable/TradesTable/TradesTable.helpers.js#L1)