### PR TITLE
positions must be an object

### DIFF
--- a/lib/util/generate_strategy_results.js
+++ b/lib/util/generate_strategy_results.js
@@ -17,7 +17,7 @@ const TRADE_FIELDS = [
 
 const formatPositions = (positions = []) => {
   if (positions.length === 0) {
-    return []
+    return {}
   }
 
   return Object.fromEntries(positions.map(p => {
@@ -90,7 +90,7 @@ module.exports = (perfManager, strategyState = {}, openPosition = null) => {
   const ret = perfManager.return()
   const retPerc = perfManager.returnPerc()
   const drawdown = perfManager.drawdown()
-  const openPositions = formatPositions(Object.values(positions))
+  const openPositions = Object.values(positions)
   const nOpens = openPositions.length
 
   return {
@@ -121,7 +121,7 @@ module.exports = (perfManager, strategyState = {}, openPosition = null) => {
 
     strategy: {
       closedPositions: formatPositions(closedPositions),
-      openPositions
+      openPositions: formatPositions(openPositions)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-strategy",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "HF strategy module",
   "main": "./index.js",
   "directories": {


### PR DESCRIPTION
In some cases the positions are treated as arrays, but it should return objects indexed by id.