### PR TITLE
Pass params as object to rest method call as per new version update

### DIFF
--- a/lib/orders/calculate_fees.js
+++ b/lib/orders/calculate_fees.js
@@ -10,7 +10,7 @@ module.exports = async (rest, order, orderParams) => {
   const { symbol, submittedAt } = orderParams
   let trades
   try {
-    trades = await rest.accountTrades(symbol, submittedAt)
+    trades = await rest.accountTrades({ symbol, start: submittedAt })
   } catch (e) {
     return null
   }

--- a/test/unit/orders/calculate_fees.js
+++ b/test/unit/orders/calculate_fees.js
@@ -44,7 +44,7 @@ describe('calc fees of trade', () => {
 
     const fees = await calculateFees(rest, order, orderParams)
 
-    assert.calledWithExactly(stubAccountTrades, symbol, orderParams.submittedAt)
+    assert.calledWithExactly(stubAccountTrades, { symbol, start: orderParams.submittedAt })
     expect(fees).not.to.be.null
     expect(fees.amount.toString()).to.be.eq('-0.004')
     expect(fees.cost.toString()).to.be.eq('-80.76')
@@ -71,7 +71,7 @@ describe('calc fees of trade', () => {
 
     const fees = await calculateFees(rest, order, orderParams)
 
-    assert.calledWithExactly(stubAccountTrades, symbol, orderParams.submittedAt)
+    assert.calledWithExactly(stubAccountTrades, { symbol, start: orderParams.submittedAt })
     expect(fees).not.to.be.null
     expect(fees.amount.toString()).to.be.eq('-80.59848')
     expect(fees.cost.toString()).to.be.eq('-80.59848')


### PR DESCRIPTION
Pass params as object to rest method call as per new version update